### PR TITLE
Remove adding socket kwargs as a string

### DIFF
--- a/pysolarmanv5/pysolarmanv5_async.py
+++ b/pysolarmanv5/pysolarmanv5_async.py
@@ -45,7 +45,6 @@ class PySolarmanV5Async(PySolarmanV5):
 
     def __init__(self, address, serial, **kwargs):
         """Constructor"""
-        kwargs.update({'socket': ''})
         super(PySolarmanV5Async, self).__init__(address, serial, **kwargs)
         self._needs_reconnect = kwargs.get("auto_reconnect", False)
         """ Auto-reconnect feature """


### PR DESCRIPTION
I'm not sure what the original intention of adding the `socket` kwarg as an empty string here, but as you can see if you create the `PySolarmanV5Async`, it always fails with the following:

```
  File "/workspaces/home-assistant-core/config/deps/solis/src/solis/cli.py", line 21, in main
    ctx.obj["solis"] = await Solis.create(ip, serial, port)
  File "/workspaces/home-assistant-core/config/deps/solis/src/solis/solis.py", line 142, in create
    self = cls(ipaddr, serial, port)
  File "/workspaces/home-assistant-core/config/deps/solis/src/solis/solis.py", line 150, in __init__
    self._modbus = pysolarmanv5.PySolarmanV5Async(
  File "/workspaces/home-assistant-core/config/deps/pysolarmanv5/pysolarmanv5/pysolarmanv5_async.py", line 49, in __init__
    super(PySolarmanV5Async, self).__init__(address, serial, **kwargs)
  File "/workspaces/home-assistant-core/config/deps/pysolarmanv5/pysolarmanv5/pysolarmanv5.py", line 106, in __init__
    self._sock_fd = self.sock.fileno()
AttributeError: 'str' object has no attribute 'fileno'
```

Therefore this PR proposes removing this line.