### PR TITLE
Tests and fixes

### DIFF
--- a/pysolarmanv5/pysolarmanv5.py
+++ b/pysolarmanv5/pysolarmanv5.py
@@ -274,6 +274,8 @@ class PySolarmanV5:
         #v5_response = self.sock.recv(1024)
         try:
             v5_response = self._data_queue.get(timeout=self.socket_timeout)
+            if v5_response == b'':
+                raise NoSocketAvailableError('Connection closed on read')
             self._data_wanted.clear()
         except TimeoutError:
             raise
@@ -348,7 +350,6 @@ class PySolarmanV5:
         self._reader_exit.set()
         self._reader_thr.join(.5)
         self._poll.unregister(self._sock_fd)
-
     def _send_receive_modbus_frame(self, mb_request_frame):
         """Encodes mb_frame, sends/receives v5_frame, decodes response
 

--- a/pysolarmanv5/pysolarmanv5_async.py
+++ b/pysolarmanv5/pysolarmanv5_async.py
@@ -2,6 +2,7 @@
 import asyncio
 from umodbus.client.serial import rtu
 from multiprocessing import Event
+from typing import Any
 from .pysolarmanv5 import NoSocketAvailableError, PySolarmanV5
 
 
@@ -45,7 +46,6 @@ class PySolarmanV5Async(PySolarmanV5):
 
     def __init__(self, address, serial, **kwargs):
         """Constructor"""
-        kwargs.update({'socket': ''})
         super(PySolarmanV5Async, self).__init__(address, serial, **kwargs)
         self._needs_reconnect = kwargs.get("auto_reconnect", False)
         """ Auto-reconnect feature """
@@ -92,6 +92,9 @@ class PySolarmanV5Async(PySolarmanV5):
         self.writer.write(b'')
         await self.writer.drain()
         self.writer.close()
+
+    def _socket_setup(self, sock: Any):
+        pass
 
 
     def _send_data(self, data: bytes):

--- a/pysolarmanv5/pysolarmanv5_async.py
+++ b/pysolarmanv5/pysolarmanv5_async.py
@@ -87,6 +87,13 @@ class PySolarmanV5Async(PySolarmanV5):
         except:
             raise NoSocketAvailableError(f'Cannot open connection to {self.address}')
 
+    async def disconnect(self) -> None:
+        self.reader_task.cancel()
+        self.writer.write(b'')
+        await self.writer.drain()
+        self.writer.close()
+
+
     def _send_data(self, data: bytes):
         """
         Sends the data received from the socket to the receiver.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+log_cli = true
+log_cli_format = %(asctime)s - [%(levelname)s] %(message)s
+log_cli_level = DEBUG

--- a/tests/setup_test.py
+++ b/tests/setup_test.py
@@ -1,0 +1,139 @@
+import socket
+import threading
+
+from pysolarmanv5 import PySolarmanV5
+import struct
+from umodbus.client.serial.redundancy_check import add_crc
+from umodbus.functions import (ReadHoldingRegisters, ReadInputRegisters, ReadCoils,
+                               create_function_from_request_pdu)
+import socketserver
+import random
+import logging
+
+socketserver.TCPServer.allow_reuse_address = True
+socketserver.TCPServer.allow_reuse_port = True
+log = logging.getLogger()
+
+
+class _Singleton(type):
+
+    _instances = {}
+
+    def __call__(cls, *args, **kwargs):
+        if cls not in cls._instances:
+            cls._instances[cls] = super(_Singleton, cls).__call__(*args, **kwargs)
+        return cls._instances[cls]
+
+
+def function_response_from_request(req: bytes):
+    func = create_function_from_request_pdu(req[2:-2])
+    slave_addr = req[1:2]
+    res = b''
+    if isinstance(func, ReadCoils):
+        res = func.create_response_pdu([random.randint(0, 255) for x in range(func.quantity)])
+    elif isinstance(func, ReadHoldingRegisters):
+        res = func.create_response_pdu([random.randint(0, 2**16 - 1) for x in range(func.quantity)])
+    elif isinstance(func, ReadInputRegisters):
+        res = func.create_response_pdu([random.randint(0, 2**16 - 1) for x in range(func.quantity)])
+    return add_crc(slave_addr + res)
+
+
+class MockDatalogger(PySolarmanV5):
+
+    def v5_frame_response_encoder(self, modbus_frame):
+        """Take a modbus RTU frame and encode it as a V5 data logging stick response frame
+
+        :param modbus_frame: Modbus RTU frame
+        :type modbus_frame: bytes
+        :return: V5 frame
+        :rtype: bytearray
+
+        """
+
+        self.v5_length = struct.pack("<H", 15 + len(modbus_frame))
+        self.v5_serial = struct.pack("<BB", self.sequence_number, self._get_next_sequence_number())
+        v5_control = struct.pack("<H", 0x1510)
+
+        v5_header = bytearray(
+            self.v5_start
+            + self.v5_length
+            + v5_control
+            + self.v5_serial
+            + self.v5_loggerserial
+        )
+
+        v5_payload = bytearray(
+            self.v5_frametype
+            + bytes.fromhex('00')
+            + self.v5_deliverytime
+            + self.v5_powerontime
+            + self.v5_offsettime
+            + modbus_frame
+        )
+
+        v5_trailer = bytearray(self.v5_checksum + self.v5_end)
+        v5_frame = v5_header + v5_payload + v5_trailer
+        v5_frame[len(v5_frame) - 2] = self._calculate_v5_frame_checksum(v5_frame)
+        return v5_frame
+
+
+class ServerHandler(socketserver.BaseRequestHandler):
+
+    def setup(self, *args, **kwargs):
+        self.sol = MockDatalogger('0.0.0.0', 2612749371, socket='', auto_reconnect=False)
+        self.count_packet = bytes.fromhex('a5010010478d69b5b50aa2006415')
+        self.cl_packets = 0
+
+    def handle(self) -> None:
+        self.request: socket.socket
+        while True:
+            data = self.request.recv(1024)
+            self.cl_packets += 1
+            if self.cl_packets == 2:
+                self.request.send(self.count_packet)
+            if data == b'':
+                break
+            else:
+                seq_no = data[5]
+                self.sol.sequence_number = data[5]
+                print('RECD: ', data)
+                log.debug(f'[SrvHandler] RECD: {data}')
+                data = bytearray(data)
+                data[3:5] = struct.pack("<H", 0x1510)
+                try:
+                    checksum = self.sol._calculate_v5_frame_checksum(bytes(data))
+                except:
+                    self.request.send(b'')
+                    break
+                data[-2:-1] = checksum.to_bytes(1, byteorder='big')
+                data = bytes(data)
+                log.debug(f'[SrvHandler] DEC: {data}')
+                try:
+                    decoded = self.sol._v5_frame_decoder(data)
+                    print(decoded)
+                    enc = function_response_from_request(decoded)
+                    log.debug(f'[SrvHandler] Generated Raw modbus: {enc.hex(" ")}')
+                    enc = self.sol.v5_frame_response_encoder(enc)
+                    log.debug(f'[SrvHandler] Sending frame: {bytes(enc).hex(" ")}')
+                    self.request.send(bytes(enc))
+                except Exception as e:
+                    log.exception(e)
+                    self.request.send(data)
+                if self.cl_packets == 2:
+                    # Uncomment for auto-reconnect tests
+                    # It is unstable, tests can fail from time to time if enabled
+                    #self.request.close()
+                    #break
+                    pass
+
+
+class SolarmanServer(metaclass=_Singleton):
+
+    def __init__(self, address, port):
+        self.srv = socketserver.TCPServer((address, port), ServerHandler)
+        self.srv.timeout = 2
+        thr = threading.Thread(target=self.run, daemon=True)
+        thr.start()
+
+    def run(self):
+        self.srv.serve_forever(2)

--- a/tests/setup_test.py
+++ b/tests/setup_test.py
@@ -59,7 +59,7 @@ class MockDatalogger(PySolarmanV5):
 
         """
 
-        self.v5_length = struct.pack("<H", 15 + len(modbus_frame))
+        self.v5_length = struct.pack("<H", 14 + len(modbus_frame))
         self.v5_serial = struct.pack(
             "<BB", self.sequence_number, self._get_next_sequence_number()
         )
@@ -75,7 +75,7 @@ class MockDatalogger(PySolarmanV5):
 
         v5_payload = bytearray(
             self.v5_frametype
-            + bytes.fromhex("00")
+            + bytes.fromhex("01")
             + self.v5_deliverytime
             + self.v5_powerontime
             + self.v5_offsettime

--- a/tests/setup_test.py
+++ b/tests/setup_test.py
@@ -4,8 +4,12 @@ import threading
 from pysolarmanv5 import PySolarmanV5
 import struct
 from umodbus.client.serial.redundancy_check import add_crc
-from umodbus.functions import (ReadHoldingRegisters, ReadInputRegisters, ReadCoils,
-                               create_function_from_request_pdu)
+from umodbus.functions import (
+    ReadHoldingRegisters,
+    ReadInputRegisters,
+    ReadCoils,
+    create_function_from_request_pdu,
+)
 import socketserver
 import asyncio
 import random
@@ -17,7 +21,6 @@ log = logging.getLogger()
 
 
 class _Singleton(type):
-
     _instances = {}
 
     def __call__(cls, *args, **kwargs):
@@ -29,18 +32,23 @@ class _Singleton(type):
 def function_response_from_request(req: bytes):
     func = create_function_from_request_pdu(req[2:-2])
     slave_addr = req[1:2]
-    res = b''
+    res = b""
     if isinstance(func, ReadCoils):
-        res = func.create_response_pdu([random.randint(0, 255) for x in range(func.quantity)])
+        res = func.create_response_pdu(
+            [random.randint(0, 255) for x in range(func.quantity)]
+        )
     elif isinstance(func, ReadHoldingRegisters):
-        res = func.create_response_pdu([random.randint(0, 2**16 - 1) for x in range(func.quantity)])
+        res = func.create_response_pdu(
+            [random.randint(0, 2**16 - 1) for x in range(func.quantity)]
+        )
     elif isinstance(func, ReadInputRegisters):
-        res = func.create_response_pdu([random.randint(0, 2**16 - 1) for x in range(func.quantity)])
+        res = func.create_response_pdu(
+            [random.randint(0, 2**16 - 1) for x in range(func.quantity)]
+        )
     return add_crc(slave_addr + res)
 
 
 class MockDatalogger(PySolarmanV5):
-
     def v5_frame_response_encoder(self, modbus_frame):
         """Take a modbus RTU frame and encode it as a V5 data logging stick response frame
 
@@ -52,7 +60,9 @@ class MockDatalogger(PySolarmanV5):
         """
 
         self.v5_length = struct.pack("<H", 15 + len(modbus_frame))
-        self.v5_serial = struct.pack("<BB", self.sequence_number, self._get_next_sequence_number())
+        self.v5_serial = struct.pack(
+            "<BB", self.sequence_number, self._get_next_sequence_number()
+        )
         v5_control = struct.pack("<H", 0x1510)
 
         v5_header = bytearray(
@@ -65,7 +75,7 @@ class MockDatalogger(PySolarmanV5):
 
         v5_payload = bytearray(
             self.v5_frametype
-            + bytes.fromhex('00')
+            + bytes.fromhex("00")
             + self.v5_deliverytime
             + self.v5_powerontime
             + self.v5_offsettime
@@ -79,10 +89,11 @@ class MockDatalogger(PySolarmanV5):
 
 
 class ServerHandler(socketserver.BaseRequestHandler):
-
     def setup(self, *args, **kwargs):
-        self.sol = MockDatalogger('0.0.0.0', 2612749371, socket='', auto_reconnect=False)
-        self.count_packet = bytes.fromhex('a5010010478d69b5b50aa2006415')
+        self.sol = MockDatalogger(
+            "0.0.0.0", 2612749371, socket="", auto_reconnect=False
+        )
+        self.count_packet = bytes.fromhex("a5010010478d69b5b50aa2006415")
         self.cl_packets = 0
 
     def handle(self) -> None:
@@ -92,22 +103,22 @@ class ServerHandler(socketserver.BaseRequestHandler):
             self.cl_packets += 1
             if self.cl_packets == 2:
                 self.request.send(self.count_packet)
-            if data == b'':
+            if data == b"":
                 break
             else:
                 seq_no = data[5]
                 self.sol.sequence_number = data[5]
-                log.debug(f'[SrvHandler] RECD: {data}')
+                log.debug(f"[SrvHandler] RECD: {data}")
                 data = bytearray(data)
                 data[3:5] = struct.pack("<H", 0x1510)
                 try:
                     checksum = self.sol._calculate_v5_frame_checksum(bytes(data))
                 except:
-                    self.request.send(b'')
+                    self.request.send(b"")
                     break
-                data[-2:-1] = checksum.to_bytes(1, byteorder='big')
+                data[-2:-1] = checksum.to_bytes(1, byteorder="big")
                 data = bytes(data)
-                log.debug(f'[SrvHandler] DEC: {data}')
+                log.debug(f"[SrvHandler] DEC: {data}")
                 try:
                     decoded = self.sol._v5_frame_decoder(data)
                     enc = function_response_from_request(decoded)
@@ -121,8 +132,8 @@ class ServerHandler(socketserver.BaseRequestHandler):
                 if self.cl_packets == 2:
                     # Uncomment for auto-reconnect tests
                     # It is unstable, tests can fail from time to time if enabled
-                    #self.request.close()
-                    #break
+                    # self.request.close()
+                    # break
                     pass
 
 
@@ -138,30 +149,30 @@ async def stream_handler(reader: asyncio.StreamReader, writer: asyncio.StreamWri
     :param writer:
     :return:
     """
-    sol = MockDatalogger('0.0.0.0', 2612749371, socket='', auto_reconnect=False)
-    count_packet = bytes.fromhex('a5010010478d69b5b50aa2006415')
+    sol = MockDatalogger("0.0.0.0", 2612749371, socket="", auto_reconnect=False)
+    count_packet = bytes.fromhex("a5010010478d69b5b50aa2006415")
     cl_packets = 0
 
     while True:
         data = await reader.read(1024)
         cl_packets += 1
-        if data == b'':
+        if data == b"":
             break
         else:
             seq_no = data[5]
             sol.sequence_number = data[5]
-            log.debug(f'[AioHandler] RECD: {data}')
+            log.debug(f"[AioHandler] RECD: {data}")
             data = bytearray(data)
             data[3:5] = struct.pack("<H", 0x1510)
             try:
                 checksum = sol._calculate_v5_frame_checksum(bytes(data))
             except:
-                writer.write(b'')
+                writer.write(b"")
                 await writer.drain()
                 break
-            data[-2:-1] = checksum.to_bytes(1, byteorder='big')
+            data[-2:-1] = checksum.to_bytes(1, byteorder="big")
             data = bytes(data)
-            log.debug(f'[AioHandler] DEC: {data}')
+            log.debug(f"[AioHandler] DEC: {data}")
             try:
                 decoded = sol._v5_frame_decoder(data)
                 enc = function_response_from_request(decoded)
@@ -182,12 +193,12 @@ async def stream_handler(reader: asyncio.StreamReader, writer: asyncio.StreamWri
             if cl_packets == 2:
                 # Uncomment for auto-reconnect tests
                 # It is unstable, tests can fail from time to time if enabled
-                #writer.close()
+                # writer.close()
                 break
-                #await random_delay()
+                # await random_delay()
                 pass
     try:
-        writer.write(b'')
+        writer.write(b"")
         await writer.drain()
         writer.close()
     except:
@@ -199,6 +210,7 @@ class SolarmanServer(metaclass=_Singleton):
     """
     Sync version of the test server
     """
+
     def __init__(self, address, port):
         self.srv = socketserver.TCPServer((address, port), ServerHandler)
         self.srv.timeout = 2
@@ -213,6 +225,7 @@ class AioSolarmanServer(metaclass=_Singleton):
     """
     Async version of the test server
     """
+
     def __init__(self, address, port):
         self.address = address
         self.port = port
@@ -225,12 +238,15 @@ class AioSolarmanServer(metaclass=_Singleton):
             thr.start()
 
     async def start_server(self):
-        await asyncio.start_server(stream_handler, host=self.address, port=self.port,
-                                   family=socket.AF_INET, reuse_address=True, reuse_port=True)
+        await asyncio.start_server(
+            stream_handler,
+            host=self.address,
+            port=self.port,
+            family=socket.AF_INET,
+            reuse_address=True,
+            reuse_port=True,
+        )
 
     def sync_runner(self):
         self.loop.create_task(self.start_server())
         self.loop.run_forever()
-
-
-

--- a/tests/setup_test.py
+++ b/tests/setup_test.py
@@ -49,6 +49,13 @@ def function_response_from_request(req: bytes):
 
 
 class MockDatalogger(PySolarmanV5):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def _socket_setup(self, sock):
+        pass
+
     def v5_frame_response_encoder(self, modbus_frame):
         """Take a modbus RTU frame and encode it as a V5 data logging stick response frame
 
@@ -149,7 +156,7 @@ async def stream_handler(reader: asyncio.StreamReader, writer: asyncio.StreamWri
     :param writer:
     :return:
     """
-    sol = MockDatalogger("0.0.0.0", 2612749371, socket="", auto_reconnect=False)
+    sol = MockDatalogger("0.0.0.0", 2612749371, auto_reconnect=False)
     count_packet = bytes.fromhex("a5010010478d69b5b50aa2006415")
     cl_packets = 0
 

--- a/tests/test_aio_solarman.py
+++ b/tests/test_aio_solarman.py
@@ -4,21 +4,25 @@ import asyncio
 import logging
 
 log = logging.getLogger()
-#server = SolarmanServer('127.0.0.1', 8899)
-server = AioSolarmanServer('127.0.0.1', 8899)
+# server = SolarmanServer('127.0.0.1', 8899)
+server = AioSolarmanServer("127.0.0.1", 8899)
 
 
 def test_async():
     async def wrapper():
-        log.debug('Async starting')
-        solarman = PySolarmanV5Async('127.0.0.1', 2612749371, auto_reconnect=True, verbose=True, socket_timeout=2)
+        log.debug("Async starting")
+        solarman = PySolarmanV5Async(
+            "127.0.0.1", 2612749371, auto_reconnect=True, verbose=True, socket_timeout=2
+        )
         await solarman.connect()
-        log.debug('Async connected!!!')
+        log.debug("Async connected!!!")
         res = await solarman.read_holding_registers(20, 4)
         assert len(res) == 4
         res = await solarman.read_holding_registers(40, 4)
         assert len(res) == 4
-        await asyncio.sleep(.2)  # wait for auto-reconnect if enabled (see SolarmanServer)
+        await asyncio.sleep(
+            0.2
+        )  # wait for auto-reconnect if enabled (see SolarmanServer)
         try:
             res = await solarman.read_holding_registers(2000, 4)
         except NoSocketAvailableError:
@@ -26,7 +30,8 @@ def test_async():
             res = await solarman.read_holding_registers(2000, 4)
         assert len(res) == 4
         await solarman.disconnect()
-        log.debug('Async disconnected!!!')
+        log.debug("Async disconnected!!!")
+
     try:
         loop = asyncio.get_running_loop()
         loop.run_until_complete(wrapper())

--- a/tests/test_aio_solarman.py
+++ b/tests/test_aio_solarman.py
@@ -1,10 +1,11 @@
-from setup_test import SolarmanServer
+from setup_test import SolarmanServer, AioSolarmanServer
 from pysolarmanv5 import PySolarmanV5Async, NoSocketAvailableError
 import asyncio
 import logging
 
 log = logging.getLogger()
-server = SolarmanServer('127.0.0.1', 8899)
+#server = SolarmanServer('127.0.0.1', 8899)
+server = AioSolarmanServer('127.0.0.1', 8899)
 
 
 def test_async():
@@ -26,4 +27,8 @@ def test_async():
         assert len(res) == 4
         await solarman.disconnect()
         log.debug('Async disconnected!!!')
-    asyncio.run(wrapper())
+    try:
+        loop = asyncio.get_running_loop()
+        loop.run_until_complete(wrapper())
+    except RuntimeError:
+        asyncio.run(wrapper())

--- a/tests/test_aio_solarman.py
+++ b/tests/test_aio_solarman.py
@@ -1,0 +1,29 @@
+from setup_test import SolarmanServer
+from pysolarmanv5 import PySolarmanV5Async, NoSocketAvailableError
+import asyncio
+import logging
+
+log = logging.getLogger()
+server = SolarmanServer('127.0.0.1', 8899)
+
+
+def test_async():
+    async def wrapper():
+        log.debug('Async starting')
+        solarman = PySolarmanV5Async('127.0.0.1', 2612749371, auto_reconnect=True, verbose=True, socket_timeout=2)
+        await solarman.connect()
+        log.debug('Async connected!!!')
+        res = await solarman.read_holding_registers(20, 4)
+        assert len(res) == 4
+        res = await solarman.read_holding_registers(40, 4)
+        assert len(res) == 4
+        await asyncio.sleep(.2)  # wait for auto-reconnect if enabled (see SolarmanServer)
+        try:
+            res = await solarman.read_holding_registers(2000, 4)
+        except NoSocketAvailableError:
+            await asyncio.sleep(1)
+            res = await solarman.read_holding_registers(2000, 4)
+        assert len(res) == 4
+        await solarman.disconnect()
+        log.debug('Async disconnected!!!')
+    asyncio.run(wrapper())

--- a/tests/test_solarman.py
+++ b/tests/test_solarman.py
@@ -4,18 +4,20 @@ from setup_test import SolarmanServer, AioSolarmanServer
 from pysolarmanv5 import PySolarmanV5, NoSocketAvailableError
 
 log = logging.getLogger()
-#server = SolarmanServer('127.0.0.1', 8899)
-server = AioSolarmanServer('127.0.0.1', 8899)
+# server = SolarmanServer('127.0.0.1', 8899)
+server = AioSolarmanServer("127.0.0.1", 8899)
 
 
 def test_sync():
-    solarman = PySolarmanV5('127.0.0.1', 2612749371, auto_reconnect=True, verbose=True, socket_timeout=2)
+    solarman = PySolarmanV5(
+        "127.0.0.1", 2612749371, auto_reconnect=True, verbose=True, socket_timeout=2
+    )
     res = solarman.read_holding_registers(20, 4)
-    log.debug(f'[Sync-HOLDING] Logger response: {res}')
+    log.debug(f"[Sync-HOLDING] Logger response: {res}")
     assert len(res) == 4
-    #time.sleep(1)
+    # time.sleep(1)
     res = solarman.read_coils(30, 1)
-    log.debug(f'[Sync-COILS] Logger response: {res}')
+    log.debug(f"[Sync-COILS] Logger response: {res}")
     assert len(res) > 0
     time.sleep(1)  # wait for auto-reconnect if enabled (see SolarmanServer)
     try:
@@ -23,7 +25,7 @@ def test_sync():
     except NoSocketAvailableError:
         time.sleep(1)
         res = solarman.read_input_registers(40, 10)
-    log.debug(f'[Sync-INPUT] Logger response: {res}')
+    log.debug(f"[Sync-INPUT] Logger response: {res}")
     assert len(res) == 10
     solarman.disconnect()
-    log.debug('[Sync] Disconnected!!!')
+    log.debug("[Sync] Disconnected!!!")

--- a/tests/test_solarman.py
+++ b/tests/test_solarman.py
@@ -1,10 +1,11 @@
 import time
 import logging
-from setup_test import SolarmanServer
+from setup_test import SolarmanServer, AioSolarmanServer
 from pysolarmanv5 import PySolarmanV5, NoSocketAvailableError
 
 log = logging.getLogger()
-server = SolarmanServer('127.0.0.1', 8899)
+#server = SolarmanServer('127.0.0.1', 8899)
+server = AioSolarmanServer('127.0.0.1', 8899)
 
 
 def test_sync():
@@ -16,8 +17,13 @@ def test_sync():
     res = solarman.read_coils(30, 1)
     log.debug(f'[Sync-COILS] Logger response: {res}')
     assert len(res) > 0
-    time.sleep(.2)  # wait for auto-reconnect if enabled (see SolarmanServer)
-    res = solarman.read_input_registers(40, 10)
+    time.sleep(1)  # wait for auto-reconnect if enabled (see SolarmanServer)
+    try:
+        res = solarman.read_input_registers(40, 10)
+    except NoSocketAvailableError:
+        time.sleep(1)
+        res = solarman.read_input_registers(40, 10)
     log.debug(f'[Sync-INPUT] Logger response: {res}')
     assert len(res) == 10
     solarman.disconnect()
+    log.debug('[Sync] Disconnected!!!')

--- a/tests/test_solarman.py
+++ b/tests/test_solarman.py
@@ -1,0 +1,23 @@
+import time
+import logging
+from setup_test import SolarmanServer
+from pysolarmanv5 import PySolarmanV5, NoSocketAvailableError
+
+log = logging.getLogger()
+server = SolarmanServer('127.0.0.1', 8899)
+
+
+def test_sync():
+    solarman = PySolarmanV5('127.0.0.1', 2612749371, auto_reconnect=True, verbose=True, socket_timeout=2)
+    res = solarman.read_holding_registers(20, 4)
+    log.debug(f'[Sync-HOLDING] Logger response: {res}')
+    assert len(res) == 4
+    #time.sleep(1)
+    res = solarman.read_coils(30, 1)
+    log.debug(f'[Sync-COILS] Logger response: {res}')
+    assert len(res) > 0
+    time.sleep(.2)  # wait for auto-reconnect if enabled (see SolarmanServer)
+    res = solarman.read_input_registers(40, 10)
+    log.debug(f'[Sync-INPUT] Logger response: {res}')
+    assert len(res) == 10
+    solarman.disconnect()


### PR DESCRIPTION
Covered by the tests:
 - both PySolarman versions 
 - read of input/holding registers and coils (sync)
 - skipping of counter packets 
 - auto reconnect
 
Fixes:
- as discussed in #34 the reader thread and all attributes used by it are needed only if self.sock is a socket object
- small changes in the auto-reconnect logic for issues spotted during testing

New: 
- disconnect method for the async version 
- NoSocketAvailableError is raised on empty response from the data logger