### PR TITLE
V5 compliance

### DIFF
--- a/pysolarmanv5/pysolarmanv5.py
+++ b/pysolarmanv5/pysolarmanv5.py
@@ -295,7 +295,11 @@ class PySolarmanV5:
             for event in events:
                 # We are registered only for inbound data on a single socket,
                 # so there is no need to check the (fileno, mask) tuples
-                data = self.sock.recv(1024)
+                try:
+                    data = self.sock.recv(1024)
+                except ConnectionResetError:
+                    self.log.debug(f'[{self.serial}] Connection RESET by peer.')
+                    data = b""
                 if data == b"":
                     self.log.debug(f"[POLL] Socket closed. Reader thread exiting.")
                     if self._data_wanted.is_set():

--- a/pysolarmanv5/pysolarmanv5.py
+++ b/pysolarmanv5/pysolarmanv5.py
@@ -316,6 +316,9 @@ class PySolarmanV5:
                 elif not data.startswith(b"\xa5"):
                     self.log.debug(f'[{self.serial}] V5_MISMATCH: {data.hex(" ")}')
                     continue
+                elif data[5] != self.sequence_number:
+                    self.log.debug(f'[{self.serial}] V5_SEQ_NO_MISMATCH: {data.hex(" ")}')
+                    continue
                 if self._data_wanted.is_set():
                     self._data_queue.put(data, timeout=self.socket_timeout)
                 else:

--- a/pysolarmanv5/pysolarmanv5.py
+++ b/pysolarmanv5/pysolarmanv5.py
@@ -313,6 +313,9 @@ class PySolarmanV5:
                     # Frame with control code 0x4710 - Counter frame
                     self.log.debug(f'[{self.serial}] COUNTER: {data.hex(" ")}')
                     continue
+                elif not data.startswith(b"\xa5"):
+                    self.log.debug(f'[{self.serial}] V5_MISMATCH: {data.hex(" ")}')
+                    continue
                 if self._data_wanted.is_set():
                     self._data_queue.put(data, timeout=self.socket_timeout)
                 else:

--- a/pysolarmanv5/pysolarmanv5_async.py
+++ b/pysolarmanv5/pysolarmanv5_async.py
@@ -148,6 +148,9 @@ class PySolarmanV5Async(PySolarmanV5):
                 # Frame with control code 0x4710 - Counter frame
                 self.log.debug(f'[{self.serial}] COUNTER: {data.hex(" ")}')
                 continue
+            elif not data.startswith(b"\xa5"):
+                self.log.debug(f'[{self.serial}] V5_MISMATCH: {data.hex(" ")}')
+                continue
             elif self.data_wanted_ev.is_set():
                 self._send_data(data)
             else:

--- a/pysolarmanv5/pysolarmanv5_async.py
+++ b/pysolarmanv5/pysolarmanv5_async.py
@@ -151,6 +151,9 @@ class PySolarmanV5Async(PySolarmanV5):
             elif not data.startswith(b"\xa5"):
                 self.log.debug(f'[{self.serial}] V5_MISMATCH: {data.hex(" ")}')
                 continue
+            elif data[5] != self.sequence_number:
+                self.log.debug(f'[{self.serial}] V5_SEQ_NO_MISMATCH: {data.hex(" ")}')
+                continue
             elif self.data_wanted_ev.is_set():
                 self._send_data(data)
             else:

--- a/tests/setup_test.py
+++ b/tests/setup_test.py
@@ -161,6 +161,8 @@ async def stream_handler(reader: asyncio.StreamReader, writer: asyncio.StreamWri
     """
     sol = MockDatalogger("0.0.0.0", 2612749371, auto_reconnect=False)
     count_packet = bytes.fromhex("a5010010478d69b5b50aa2006415")
+    non_v5_packet = bytes.fromhex("41542b595a434d505645523d4d57335f3136555f353430365f322e32370d0a0d0a")
+    gibberish = bytes.fromhex("aa030a00000000000000000000be9c")
     cl_packets = 0
 
     while True:
@@ -198,6 +200,12 @@ async def stream_handler(reader: asyncio.StreamReader, writer: asyncio.StreamWri
                 # Write counter packet and wait some time to be consumed
                 await random_delay()
                 writer.write(count_packet)
+                await writer.drain()
+                await random_delay()
+                writer.write(gibberish)
+                await writer.drain()
+                await random_delay()
+                writer.write(non_v5_packet)
                 await writer.drain()
                 await random_delay()
             if cl_packets == 2:

--- a/tests/test_aio_solarman.py
+++ b/tests/test_aio_solarman.py
@@ -25,9 +25,13 @@ def test_async():
         )  # wait for auto-reconnect if enabled (see SolarmanServer)
         try:
             res = await solarman.read_holding_registers(2000, 4)
+            res = await solarman.read_holding_registers(200, 4)
+            res = await solarman.read_holding_registers(20, 4)
         except NoSocketAvailableError:
             await asyncio.sleep(1)
             res = await solarman.read_holding_registers(2000, 4)
+            res = await solarman.read_holding_registers(200, 4)
+            res = await solarman.read_holding_registers(20, 4)
         assert len(res) == 4
         await solarman.disconnect()
         log.debug("Async disconnected!!!")

--- a/tests/test_solarman.py
+++ b/tests/test_solarman.py
@@ -22,9 +22,13 @@ def test_sync():
     time.sleep(1)  # wait for auto-reconnect if enabled (see SolarmanServer)
     try:
         res = solarman.read_input_registers(40, 10)
+        res = solarman.read_input_registers(50, 10)
+        res = solarman.read_input_registers(60, 10)
     except NoSocketAvailableError:
         time.sleep(1)
         res = solarman.read_input_registers(40, 10)
+        res = solarman.read_input_registers(50, 10)
+        res = solarman.read_input_registers(60, 10)
     log.debug(f"[Sync-INPUT] Logger response: {res}")
     assert len(res) == 10
     solarman.disconnect()


### PR DESCRIPTION
- Packets which do not conform to the V5 specification are discarded
- Packets not intended for the current PysolrmanV5 instance are dropped

As for the latter I had a case with two daemons, one connected 24/7 collecting data/metrics and one used for inverter programming started by a timer.service / cronjob. Initially it was a mess when they overlaps.

Credited @Dummy0815 for the idea as a co-author.