### PR TITLE
Handle timeout in data receiver and amend connection closing

### DIFF
--- a/pysolarmanv5/pysolarmanv5.py
+++ b/pysolarmanv5/pysolarmanv5.py
@@ -308,7 +308,7 @@ class PySolarmanV5:
                         self._reconnect()
                         if self.sock:
                             self.log.debug(
-                                f"[POLL] Data expected. Will retry the last request"
+                                f"[POLL] Data expected. Will retry the last request: {self._last_frame.hex(' ')}"
                             )
                             self.sock.sendall(self._last_frame)
                             return
@@ -345,7 +345,8 @@ class PySolarmanV5:
             try:
                 self.sock.send(b"")
                 self.sock.close()
-            except OSError:
+            except OSError as e:
+                self.log.debug(f"Closing reader thread failed: {e}")
                 pass
             self._reader_exit.set()
         if self._auto_reconnect:
@@ -379,7 +380,8 @@ class PySolarmanV5:
         try:
             self.sock.send(b"")
             self.sock.close()
-        except OSError:
+        except OSError as e:
+            self.log.debug(f"Closing socket failed: {e}")
             pass
         self._reader_thr.join(0.5)
         self._poll.unregister(self._sock_fd)
@@ -417,7 +419,8 @@ class PySolarmanV5:
             sock = socket.create_connection(
                 (self.address, self.port), self.socket_timeout
             )
-        except OSError:
+        except OSError as e:
+            self.log.debug(f"Socket creation failed: {e}")
             return None
         return sock
 


### PR DESCRIPTION
The origin of these changes is an attempt to find solution/workaround to a problem in an environment with Deye SUN-8K-SG04P3-EU inverter and a logger with firmware version LSW3_15_FFFF_1.0.9E when using Solarman Home Assistant integration. See my comments in the discussion in [home_assistant_solarman issue #523](https://github.com/StephanJoubert/home_assistant_solarman/issues/523).

This PR contains three group of changes (commits):

1. Add more debug logging (that was used to investigate the problem in the environment)
2. Add better handling of timeout and queue empty exceptions
3. Fix socket closing

Some of these changes might make sense also on the async side, but I have no feasible environment to test those and therefore I did not touch the async side at all. 