### PR TITLE
Fix socket closing, episode 2

### DIFF
--- a/pysolarmanv5/pysolarmanv5.py
+++ b/pysolarmanv5/pysolarmanv5.py
@@ -385,6 +385,7 @@ class PySolarmanV5:
 
         """
         self._data_wanted.clear()
+        self._auto_reconnect = False
         self._reader_exit.set()
         try:
             if self.sock:


### PR DESCRIPTION
While making changes to address linter findings I found out that `_data_receiver` will re-open a connection that is closed by `disconnect` call if `auto-reconnect` is on. 

Added disabling of auto-reconnect when the connection is closed by the api user by calling `disconnect`.

(Linter fixes PR will come on top of this)