### PR TITLE
Fix linter findings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,11 +19,11 @@ show:
 
 .PHONY: black # Run black
 black:
-	venv/bin/python3 -m black pysolarmanv5/*.py
+	venv/bin/python3 -m black pysolarmanv5/*.py utils/*.py
 
 .PHONY: lint # Run lint
 lint:
-	venv/bin/python3 -m pylint pysolarmanv5/*.py -d C0103 -d C0302 -d C0330 -d C0413 -d R0902 -d R0911 -d R0912 -d R0913 -d R0914 -d R0915 -d W0613 -d W0703 -d W0707 || true
+	venv/bin/python3 -m pylint **/*.py || true
 
 .PHONY: test # Run pytest
 test:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,3 +35,15 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 packages = ["pysolarmanv5"]
+
+[tool.pylint.MAIN]
+ignore-paths='docs,examples,tests' 
+
+[tool.pylint."MESSAGES CONTROL"]
+# Reasons for disabling:
+# format: formatting is handled by black
+
+disable = [
+    "format",
+]
+

--- a/pysolarmanv5/__init__.py
+++ b/pysolarmanv5/__init__.py
@@ -1,9 +1,12 @@
+"""This is a Python module to interact with Solarman (IGEN-Tech) v5 based solar
+inverter data loggers"""
+
 from pysolarmanv5.pysolarmanv5 import PySolarmanV5
 from pysolarmanv5.pysolarmanv5_async import PySolarmanV5Async
 from pysolarmanv5.pysolarmanv5 import V5FrameError
 from pysolarmanv5.pysolarmanv5 import NoSocketAvailableError
 
-name = "pysolarmanv5"
+name = "pysolarmanv5"  # pylint: disable=invalid-name (C0103)
 
 __all__ = [
     "PySolarmanV5",

--- a/pysolarmanv5/pysolarmanv5_async.py
+++ b/pysolarmanv5/pysolarmanv5_async.py
@@ -5,6 +5,9 @@ from multiprocessing import Event
 from umodbus.client.serial import rtu
 from .pysolarmanv5 import NoSocketAvailableError, PySolarmanV5
 
+# Disable `invalid-overridden-method` rule. The class `PySolarmanV5Async` overrides
+# (=redefines) non-async methods from `PySolarmanV5`.
+# The override in this case is not a problem in practice.
 
 # This could be avoided by changing the class hierarchy.
 # One way would be to introduce a common base class for async and sync classes

--- a/utils/solarman_scan.py
+++ b/utils/solarman_scan.py
@@ -4,6 +4,7 @@ import socket
 
 
 def main():
+    """Solarman data logger scanner"""
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
@@ -18,7 +19,7 @@ def main():
             data = sock.recv(1024)
         except socket.timeout:
             break
-        keys = dict.fromkeys(['ipaddress', 'mac', 'serial'])
+        keys = dict.fromkeys(["ipaddress", "mac", "serial"])
         values = data.decode().split(",")
         result = dict(zip(keys, values))
         print(result)


### PR DESCRIPTION
~~This PR is stacked on  top of #53~~

This PR has changes:

1. Move linter configuration to pyproject.toml out of `Makefile`. Also disabled the linter rule `format` in favor of `black`
2. Changes to address linter findings. They are split in 3 commits:
   1.  Miscellaneous linter finding fixes.
   2. Disable the linter rule `invalid-overridden-method` in async variant. See the commit message for rationale and possible further development.
   3. Changed logging to use the recommended lazy logging message formatting instead of f-string formatting. (note: f-string formatting could be allowed (by disabling a linter rule))

Also formatted files with `make black`.

Now both `make lint` and `make black` should produce clean results.