### PR TITLE
Double CRC handling 

### DIFF
--- a/pysolarmanv5/pysolarmanv5.py
+++ b/pysolarmanv5/pysolarmanv5.py
@@ -423,7 +423,7 @@ class PySolarmanV5:
         mb_response_frame = self._v5_frame_decoder(v5_response_frame)
         return mb_response_frame
 
-    def _handle_bogus(self, frame: bytes) -> bytes:
+    def _handle_double_crc(self, frame: bytes) -> bytes:
         """
         Strip extra zeroes in case that the frame has double CRC applied
 
@@ -453,7 +453,7 @@ class PySolarmanV5:
         try:
             modbus_values = rtu.parse_response_adu(mb_response_frame, mb_request_frame)
         except struct.error:
-            response = self._handle_bogus(mb_response_frame)
+            response = self._handle_double_crc(mb_response_frame)
             modbus_values = rtu.parse_response_adu(response, mb_request_frame)
         return modbus_values
 

--- a/pysolarmanv5/pysolarmanv5.py
+++ b/pysolarmanv5/pysolarmanv5.py
@@ -452,9 +452,12 @@ class PySolarmanV5:
         mb_response_frame = self._send_receive_modbus_frame(mb_request_frame)
         try:
             modbus_values = rtu.parse_response_adu(mb_response_frame, mb_request_frame)
-        except struct.error:
+        except struct.error as e:
             response = self._handle_double_crc(mb_response_frame)
-            modbus_values = rtu.parse_response_adu(response, mb_request_frame)
+            if len(response) != len(mb_response_frame):
+                modbus_values = rtu.parse_response_adu(response, mb_request_frame)
+            else:
+                raise e
         return modbus_values
 
     def _create_socket(self):

--- a/pysolarmanv5/pysolarmanv5_async.py
+++ b/pysolarmanv5/pysolarmanv5_async.py
@@ -2,9 +2,11 @@
 
 import errno
 import asyncio
+import struct
 
 from multiprocessing import Event
 from umodbus.client.serial import rtu
+from umodbus.client.serial.redundancy_check import get_crc
 
 from .pysolarmanv5 import NoSocketAvailableError, PySolarmanV5
 
@@ -252,6 +254,23 @@ class PySolarmanV5Async(PySolarmanV5):
         mb_response_frame = self._v5_frame_decoder(v5_response_frame)
         return mb_response_frame
 
+    def _handle_bogus(self, frame: bytes) -> bytes:
+        """
+        Strip extra zeroes in case that the frame has double CRC applied
+
+        :param frame: RTU response
+        :return: modified (if necessary) RTU frame
+        """
+
+        zeroes = bytes.fromhex('0000')
+        if not frame.endswith(zeroes):
+            return frame
+        stripped = frame[:-2]
+        if get_crc(stripped[:-2]) == stripped[-2:]:
+            return stripped
+        else:
+            return frame
+
     async def _get_modbus_response(self, mb_request_frame):
         """Returns mb response values for a given mb_request_frame
 
@@ -262,7 +281,11 @@ class PySolarmanV5Async(PySolarmanV5):
 
         """
         mb_response_frame = await self._send_receive_modbus_frame(mb_request_frame)
-        modbus_values = rtu.parse_response_adu(mb_response_frame, mb_request_frame)
+        try:
+            modbus_values = rtu.parse_response_adu(mb_response_frame, mb_request_frame)
+        except struct.error:
+            response = self._handle_bogus(mb_response_frame)
+            modbus_values = rtu.parse_response_adu(response, mb_request_frame)
         return modbus_values
 
     async def read_input_registers(self, register_addr, quantity):

--- a/pysolarmanv5/pysolarmanv5_async.py
+++ b/pysolarmanv5/pysolarmanv5_async.py
@@ -6,7 +6,6 @@ import struct
 
 from multiprocessing import Event
 from umodbus.client.serial import rtu
-from umodbus.client.serial.redundancy_check import get_crc
 
 from .pysolarmanv5 import NoSocketAvailableError, PySolarmanV5
 

--- a/pysolarmanv5/pysolarmanv5_async.py
+++ b/pysolarmanv5/pysolarmanv5_async.py
@@ -265,9 +265,12 @@ class PySolarmanV5Async(PySolarmanV5):
         mb_response_frame = await self._send_receive_modbus_frame(mb_request_frame)
         try:
             modbus_values = rtu.parse_response_adu(mb_response_frame, mb_request_frame)
-        except struct.error:
+        except struct.error as e:
             response = self._handle_double_crc(mb_response_frame)
-            modbus_values = rtu.parse_response_adu(response, mb_request_frame)
+            if len(response) != len(mb_response_frame):
+                modbus_values = rtu.parse_response_adu(response, mb_request_frame)
+            else:
+                raise e
         return modbus_values
 
     async def read_input_registers(self, register_addr, quantity):

--- a/pysolarmanv5/pysolarmanv5_async.py
+++ b/pysolarmanv5/pysolarmanv5_async.py
@@ -254,23 +254,6 @@ class PySolarmanV5Async(PySolarmanV5):
         mb_response_frame = self._v5_frame_decoder(v5_response_frame)
         return mb_response_frame
 
-    def _handle_bogus(self, frame: bytes) -> bytes:
-        """
-        Strip extra zeroes in case that the frame has double CRC applied
-
-        :param frame: RTU response
-        :return: modified (if necessary) RTU frame
-        """
-
-        zeroes = bytes.fromhex('0000')
-        if not frame.endswith(zeroes):
-            return frame
-        stripped = frame[:-2]
-        if get_crc(stripped[:-2]) == stripped[-2:]:
-            return stripped
-        else:
-            return frame
-
     async def _get_modbus_response(self, mb_request_frame):
         """Returns mb response values for a given mb_request_frame
 
@@ -284,7 +267,7 @@ class PySolarmanV5Async(PySolarmanV5):
         try:
             modbus_values = rtu.parse_response_adu(mb_response_frame, mb_request_frame)
         except struct.error:
-            response = self._handle_bogus(mb_response_frame)
+            response = self._handle_double_crc(mb_response_frame)
             modbus_values = rtu.parse_response_adu(response, mb_request_frame)
         return modbus_values
 


### PR DESCRIPTION
The discussion in https://github.com/jmccrohan/pysolarmanv5/issues/62 reveals that some data loggers/inverters apply double CRC over the modbus frame making it unreadable by the standard libraries. Therefore, some bytes must be removed in order the RTU frame to conform to the protocol.