### PR TITLE
V5 exceptions handling

### DIFF
--- a/pysolarmanv5/pysolarmanv5.py
+++ b/pysolarmanv5/pysolarmanv5.py
@@ -15,6 +15,7 @@ from random import randrange
 
 from umodbus.client.serial import rtu
 from umodbus.client.serial.redundancy_check import get_crc
+from umodbus.exceptions import error_code_to_exception_map
 
 
 _WIN_PLATFORM = platform.system() == "Windows"
@@ -256,7 +257,11 @@ class PySolarmanV5:
         modbus_frame = v5_frame[25 : frame_len - 2]
 
         if len(modbus_frame) < 5:
-            raise V5FrameError("V5 frame does not contain a valid Modbus RTU frame")
+            if len(modbus_frame) > 0 and error_code_to_exception_map.get(modbus_frame[0]):
+                err = error_code_to_exception_map.get(modbus_frame[0])
+                raise V5FrameError(f"V5 Modbus EXCEPTION: {err.__name__}")
+            else:
+                raise V5FrameError("V5 frame does not contain a valid Modbus RTU frame")
 
         return modbus_frame
 

--- a/tests/setup_test.py
+++ b/tests/setup_test.py
@@ -34,6 +34,10 @@ class _Singleton(type):
 
 def function_response_from_request(req: bytes):
     func = create_function_from_request_pdu(req[2:-2])
+    if func.starting_address > 4000:
+        ex_code = random.choice([1, 2, 3, 4, 5, 6])
+        return struct.pack("<H", ex_code)
+
     slave_addr = req[1:2]
     res = b""
     if isinstance(func, ReadCoils):

--- a/tests/test_solarman.py
+++ b/tests/test_solarman.py
@@ -1,7 +1,10 @@
 import time
 import logging
+
+import pytest
+
 from setup_test import SolarmanServer, AioSolarmanServer
-from pysolarmanv5 import PySolarmanV5, NoSocketAvailableError
+from pysolarmanv5 import PySolarmanV5, NoSocketAvailableError, V5FrameError
 
 log = logging.getLogger()
 # server = SolarmanServer('127.0.0.1', 8899)
@@ -10,7 +13,7 @@ server = AioSolarmanServer("127.0.0.1", 8899)
 
 def test_sync():
     solarman = PySolarmanV5(
-        "127.0.0.1", 2612749371, auto_reconnect=True, verbose=True, socket_timeout=2
+        "127.0.0.1", 2612749371, auto_reconnect=True, verbose=True, socket_timeout=5
     )
     res = solarman.read_holding_registers(20, 4)
     log.debug(f"[Sync-HOLDING] Logger response: {res}")
@@ -31,5 +34,22 @@ def test_sync():
         res = solarman.read_input_registers(60, 10)
     log.debug(f"[Sync-INPUT] Logger response: {res}")
     assert len(res) == 10
+
     solarman.disconnect()
+    time.sleep(0.6)
+    assert solarman._reader_thr.is_alive() is False
     log.debug("[Sync] Disconnected!!!")
+
+    log.debug("[Sync] ===== Starting exception test =====")
+    solarman._reconnect()
+
+    with pytest.raises(V5FrameError, match="V5 Modbus EXCEPTION") as e_info:
+        res = solarman.read_holding_registers(4500, 4)
+
+    assert e_info.type is V5FrameError
+    log.debug(f"[SyncException] {e_info}")
+    try:
+        solarman.disconnect()
+    except:
+        pass
+


### PR DESCRIPTION
The datalogger is sending non-standard MODBUS exceptions which can be detected. Most of the time the exception code is 0x05 (ACKNOWLEDGE ERROR), but the whole range supported by umodbus is handled.

Few examples:
```python
V5FrameError('V5 Modbus EXCEPTION: IllegalDataAddressError')
V5FrameError('V5 Modbus EXCEPTION: ServerDeviceBusyError')
```
The test server now throws  random exception when the requested address is above 4000.  The sync and async tests have been updated accordingly.

Requested by @davidrapan [in this discussion](https://github.com/davidrapan/ha-solarman/discussions/132#discussioncomment-10529382)