### PR TITLE
PySolarmanV5 UDP unicast scanner

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -26,3 +26,11 @@ Solarman Proxy
 
 .. literalinclude:: ../examples/solarman_proxy.py
    :linenos:
+
+
+Unicats scan
+^^^^^^^^^^^^
+
+.. code-block:: console
+
+    (venv) user@host:~/github/pysolarmanv5 $ python3 utils/solarman_uni_scan.py wlan0

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -28,7 +28,7 @@ Solarman Proxy
    :linenos:
 
 
-Unicats scan
+Unicast scan
 ^^^^^^^^^^^^
 
 .. code-block:: console

--- a/docs/utilities.rst
+++ b/docs/utilities.rst
@@ -9,6 +9,12 @@ Solarman Scan Utility
 .. literalinclude:: ../utils/solarman_scan.py
    :linenos:
 
+Solarman Unicast Scanner
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. literalinclude:: ../utils/solarman_uni_scan.py
+    :lineos:
+
 Solarman Decoder
 ^^^^^^^^^^^^^^^^
 

--- a/utils/solarman_uni_scan.py
+++ b/utils/solarman_uni_scan.py
@@ -1,0 +1,112 @@
+import asyncio
+import ipaddress
+import socket
+import subprocess
+import sys
+import platform
+from concurrent.futures import ThreadPoolExecutor
+from typing import List, Optional
+
+MagicONE = "WIFIKIT-214028-READ"
+MagicTWO = "HF-A11ASSISTHREAD"
+ProbeExecutor = ThreadPoolExecutor(max_workers=100)
+
+
+class SolarmanProbe:
+
+    def __init__(self, address: str):
+        self.addr = address
+        self.found = False
+        self.MAC = None
+        self.SERIAL = None
+
+    async def run(self):
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(ProbeExecutor, self.scan)
+
+    def scan(self):
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.connect((self.addr, 48899))
+        sock.settimeout(0.5)
+        sock.sendall(MagicONE.encode())
+        data = None
+        try:
+            data = sock.recv(1024)
+        except socket.timeout:
+            try:
+                sock.settimeout(0.5)
+                sock.sendall(MagicTWO.encode())
+                data = sock.recv(1024)
+            except:
+                pass
+        except:
+            pass
+        if data is not None:
+            data = data.decode().strip().split(",")
+            self.MAC = data[1]
+            self.SERIAL = data[2]
+            self.found = True
+
+    def __format__(self, format_spec):
+        return (
+            f"<SolarmanLogger> addr: {self.addr} mac: {self.MAC} serial: {self.SERIAL}"
+        )
+
+
+def get_address(iface: str) -> Optional[str]:
+    proc = subprocess.Popen(
+        ["ip", "addr", "show", iface], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL
+    )
+    proc.wait()
+    stdout = proc.stdout
+    if proc.returncode != 0:
+        return
+    stdout = stdout.read().decode().split("\n")
+    addr = None
+    for l in stdout:
+        if "inet" in l and "inet6" not in l:
+            addr = l.strip(" ").split(" ")[1]
+    if addr is None or addr == "":
+        return None
+    return addr
+
+
+def gen_ips(address: str) -> List[str]:
+    addr = []
+    try:
+        iface = ipaddress.ip_interface(address)
+        if iface.ip.is_link_local or iface.ip.is_loopback or iface.ip.is_multicast:
+            return addr
+        addr = [str(h) for h in iface.network.hosts() if h != iface.ip]
+    except Exception as e:
+        print(f"{e}")
+        return addr
+    return addr
+
+
+async def aio_main(probes: List[SolarmanProbe]):
+    loop = asyncio.get_running_loop()
+    coro = [r.run() for r in probes]
+    print(f"Starting scan with {len(coro)} probes")
+    await asyncio.gather(*coro)
+    for p in probes:
+        if p.found:
+            print(f"{p}")
+
+
+if __name__ == "__main__":
+    if platform.system().lower() != 'linux':
+        print(f"This platform is not supported")
+        sys.exit(1)
+    args = sys.argv[1:]
+    if len(args) == 0:
+        print(f"{sys.argv[0]} requires an interface name (e.g. eth0)")
+        sys.exit(1)
+    local_addr = get_address(args[0])
+    if local_addr is None:
+        print(f"{args[0]} seems to be an invalid interface name")
+        sys.exit(1)
+    ips = gen_ips(local_addr)
+    loop = asyncio.new_event_loop()
+    probes = [SolarmanProbe(ip) for ip in ips]
+    loop.run_until_complete(aio_main(probes))


### PR DESCRIPTION
- Unicast scanner for solarman data loggers. Only an interface name is required in order the network to be scanned.
- It's relatively fast (~1.5 - 2 seconds on a /24 network)
- Should help if the broadcast version does not work for some reason (as in #72)
- Linux only