### PR TITLE
PySolarmanV5Async connect timeout

### DIFF
--- a/pysolarmanv5/pysolarmanv5_async.py
+++ b/pysolarmanv5/pysolarmanv5_async.py
@@ -75,9 +75,10 @@ class PySolarmanV5Async(PySolarmanV5):
         """
         loop = asyncio.get_running_loop()
         try:
-            self.reader, self.writer = await asyncio.open_connection(
+            self.reader, self.writer = await  asyncio.wait_for(asyncio.open_connection(
                 self.address, self.port
-            )
+            ), self.socket_timeout)
+
             self.reader_task = loop.create_task(self._conn_keeper(), name="ConnKeeper")
         except Exception as e:  # pylint: disable=broad-exception-caught
             raise NoSocketAvailableError(

--- a/pysolarmanv5/pysolarmanv5_async.py
+++ b/pysolarmanv5/pysolarmanv5_async.py
@@ -75,10 +75,9 @@ class PySolarmanV5Async(PySolarmanV5):
         """
         loop = asyncio.get_running_loop()
         try:
-            self.reader, self.writer = await  asyncio.wait_for(asyncio.open_connection(
+            self.reader, self.writer = await asyncio.wait_for(asyncio.open_connection(
                 self.address, self.port
             ), self.socket_timeout)
-
             self.reader_task = loop.create_task(self._conn_keeper(), name="ConnKeeper")
         except Exception as e:  # pylint: disable=broad-exception-caught
             raise NoSocketAvailableError(


### PR DESCRIPTION
The socket_timeout value should be used on connect, otherwise the connection attempt can be blocked forever.

Should fix this issue reported in [ha-solarman](https://github.com/davidrapan/ha-solarman/issues/274)