### PR TITLE
[Async]  NoSocketAvailableError - auto reconnect: off (closes #85)

### DIFF
--- a/pysolarmanv5/pysolarmanv5_async.py
+++ b/pysolarmanv5/pysolarmanv5_async.py
@@ -208,6 +208,7 @@ class PySolarmanV5Async(PySolarmanV5):
         :return: None
 
         """
+        data = b""
         while True:
             try:
                 data = await self.reader.read(1024)
@@ -234,7 +235,7 @@ class PySolarmanV5Async(PySolarmanV5):
                 self.log.debug("Data received but nobody waits for it... Discarded")
         self.reader = None
         self.writer = None
-        # self._send_data(b"")
+
         if self._needs_reconnect:
             self.log.debug(
                 "[%s] Auto reconnect enabled. Will try to restart the socket reader",
@@ -242,6 +243,9 @@ class PySolarmanV5Async(PySolarmanV5):
             )
             loop = asyncio.get_running_loop()
             loop.create_task(self.reconnect())
+        else:
+            if self.data_wanted_ev.is_set():
+               self._send_data(data)
 
     async def _send_receive_frame(self, frame: bytes) -> bytes:
         """

--- a/pysolarmanv5/pysolarmanv5_async.py
+++ b/pysolarmanv5/pysolarmanv5_async.py
@@ -276,7 +276,7 @@ class PySolarmanV5Async(PySolarmanV5):
             raise NoSocketAvailableError("Connection already closed") from exc
         except NoSocketAvailableError:
             raise
-        except TimeoutError:
+        except asyncio.exceptions.TimeoutError:
             raise
         except OSError as exc:
             if exc.errno == errno.EHOSTUNREACH:

--- a/tests/test_aio_solarman.py
+++ b/tests/test_aio_solarman.py
@@ -14,7 +14,7 @@ def test_async():
     async def wrapper():
         log.debug("Async starting")
         solarman = PySolarmanV5Async(
-            "127.0.0.1", 2612749371, auto_reconnect=True, verbose=True, socket_timeout=5
+            "127.0.0.1", 2612749371, auto_reconnect=True, verbose=True, socket_timeout=10
         )
         await solarman.connect()
         log.debug("Async connected!!!")
@@ -46,6 +46,46 @@ def test_async():
 
         assert e_info.type is V5FrameError
         log.debug(f"[ASyncException] {e_info}")
+
+    try:
+        loop = asyncio.get_running_loop()
+        loop.run_until_complete(wrapper())
+    except RuntimeError:
+        asyncio.run(wrapper())
+
+
+def test_async_no_socket_available():
+    async def wrapper():
+        log.debug("Async NoSocketAvailable Test - starting")
+        solarman = PySolarmanV5Async(
+            "127.0.0.1", 2612749271, auto_reconnect=False, verbose=True, socket_timeout=5
+        )
+        await solarman.connect()
+        log.debug("Async connected!!!")
+        with pytest.raises(NoSocketAvailableError) as einfo:
+            res = await solarman.read_holding_registers(20, 4)
+        assert einfo.type is NoSocketAvailableError
+
+
+    try:
+        loop = asyncio.get_running_loop()
+        loop.run_until_complete(wrapper())
+    except RuntimeError:
+        asyncio.run(wrapper())
+
+
+def test_async_timeout_error():
+    async def wrapper():
+        log.debug("Async TimeoutError Test - starting")
+        solarman = PySolarmanV5Async(
+            "127.0.0.1", 2612749271, auto_reconnect=True, verbose=True, socket_timeout=1.5
+        )
+        await solarman.connect()
+        log.debug("Async connected!!!")
+        with pytest.raises(asyncio.exceptions.TimeoutError) as einfo:
+            res = await solarman.read_holding_registers(20, 4)
+        assert einfo.type is asyncio.exceptions.TimeoutError
+
 
     try:
         loop = asyncio.get_running_loop()


### PR DESCRIPTION
[Async] Raise NoSocketAvailableError on read error when auto reconnect is not enabled (closes #85)

This returns the NoSocketAvailableError in case that the auto-reconnect option is turned off, allowing the reader to fail much faster.

Updated tests covering both variants:

 - NoSocketAvailableError (auto-reconnect: off)
 - TimeoutError (auto-reconnect: on)