### PR TITLE
CI + Docker image

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,0 +1,13 @@
+name: Lint
+
+on: [push, pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: psf/black@stable

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,39 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  DOCKER_BUILDKIT: 1
+  IMAGE_NAME: ghcr.io/${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ github.sha }}
+            ${{ github.ref_name == 'main' && format('{0}:latest', env.IMAGE_NAME) || '' }}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,27 @@
+name: Run Pytest
+
+on: [push, pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install pytest .
+
+      - name: Run Pytest
+        run: |
+          pytest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+# syntax=docker/dockerfile:1
+FROM python:3.13-alpine
+
+# mount current directory to /app
+# install with pip
+RUN --mount=type=bind,rw,source=.,target=/src \
+    pip install --no-cache-dir /src
+
+CMD echo "Available commands:" && find /usr/local/bin -type f -name 'solarman*' -exec basename {} \;

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ To install the latest development version from git, run:
 
 This will also install the tools from the [utils](/utils) directory.
 
+## Docker
+
+To run the tools in the docker image, run:
+
+`docker run --rm ghcr.io/jmccrohan/pysolarmanv5:latest`
+
 ## Projects using pysolarmanv5
 
 - [davidrapan/ha-solarman](https://github.com/davidrapan/ha-solarman)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -2,22 +2,22 @@ import os
 import sys
 from datetime import date
 
-sys.path.insert(0, os.path.abspath('../'))
+sys.path.insert(0, os.path.abspath("../"))
 
-project = 'pysolarmanv5'
+project = "pysolarmanv5"
 copyright = f"{date.today().year}, Jonathan McCrohan"
-author = 'Jonathan McCrohan <jmccrohan@gmail.com>'
+author = "Jonathan McCrohan <jmccrohan@gmail.com>"
 
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.autosectionlabel',
-    'sphinx.ext.viewcode',
-    'sphinx.ext.todo',
-    'myst_parser',
-    'sphinxcontrib.packetdiag',
-    ]
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosectionlabel",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.todo",
+    "myst_parser",
+    "sphinxcontrib.packetdiag",
+]
 
-html_theme = 'furo'
+html_theme = "furo"
 
 html_theme_options = {
     "source_repository": "https://github.com/jmccrohan/pysolarmanv5/",
@@ -26,21 +26,21 @@ html_theme_options = {
 }
 
 autodoc_default_options = {
-    'members': True,
-    'member-order': 'bysource',
+    "members": True,
+    "member-order": "bysource",
     #'private-members': True,
-    }
+}
 
 autodoc_mock_imports = ["umodbus"]
 
 autosectionlabel_prefix_document = True
 
-packetdiag_html_image_format = 'SVG'
+packetdiag_html_image_format = "SVG"
 
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
 html_css_files = [
-        'css/custom.css',
-        ]
+    "css/custom.css",
+]
 
-#todo_include_todos = True
+# todo_include_todos = True

--- a/examples/async_client_example.py
+++ b/examples/async_client_example.py
@@ -1,4 +1,5 @@
-""" A basic client demonstrating how to use the async version of pysolarmanv5."""
+"""A basic client demonstrating how to use the async version of pysolarmanv5."""
+
 from pysolarmanv5 import PySolarmanV5Async
 import asyncio
 
@@ -11,7 +12,12 @@ async def main():
     respectively.
     """
     modbus = PySolarmanV5Async(
-        '192.168.1.121', 1234567890, port=8899, mb_slave_id=1, verbose=False, auto_reconnect=True
+        "192.168.1.121",
+        1234567890,
+        port=8899,
+        mb_slave_id=1,
+        verbose=False,
+        auto_reconnect=True,
     )
     await modbus.connect()
 
@@ -27,14 +33,17 @@ async def main():
     """Query single input register, apply scaling, result as a float"""
 
     print(
-        await modbus.read_input_register_formatted(register_addr=33035, quantity=1, scale=0.1)
+        await modbus.read_input_register_formatted(
+            register_addr=33035, quantity=1, scale=0.1
+        )
     )
 
     """Query two input registers, shift first register up by 16 bits, result as a signed int, """
     print(
-        await modbus.read_input_register_formatted(register_addr=33079, quantity=2, signed=1)
+        await modbus.read_input_register_formatted(
+            register_addr=33079, quantity=2, signed=1
+        )
     )
-
 
     """Query single holding register, apply bitmask and bitshift left (extract bit1 from register)"""
     print(
@@ -44,6 +53,7 @@ async def main():
     )
 
     await modbus.disconnect()
+
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/examples/client_example.py
+++ b/examples/client_example.py
@@ -1,4 +1,5 @@
-""" A basic client demonstrating how to use pysolarmanv5."""
+"""A basic client demonstrating how to use pysolarmanv5."""
+
 from pysolarmanv5 import PySolarmanV5
 
 
@@ -40,6 +41,7 @@ def main():
     )
 
     modbus.disconnect()
+
 
 if __name__ == "__main__":
     main()

--- a/examples/register_scan.py
+++ b/examples/register_scan.py
@@ -1,4 +1,5 @@
-""" Scan Modbus registers to find valid registers"""
+"""Scan Modbus registers to find valid registers"""
+
 from pysolarmanv5 import PySolarmanV5, V5FrameError
 import umodbus.exceptions
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,12 @@ version = "3.0.6"
 description = "A Python library for interacting with Solarman (IGEN-Tech) v5 based Solar Data Loggers"
 readme = "README.md"
 requires-python = ">=3.8"
-license = {text = "MIT License"}
+license = "MIT"
 authors = [{name = "Jonathan McCrohan", email = "jmccrohan@gmail.com"}]
 keywords = ["solarman", "igen-tech", "modbus", "solar", "inverter", "solarmanv5"]
 classifiers = [
     "Programming Language :: Python :: 3",
     "Topic :: Utilities",
-    "License :: OSI Approved :: MIT License",
 ]
 dependencies = [
     "umodbus",

--- a/pysolarmanv5/pysolarmanv5.py
+++ b/pysolarmanv5/pysolarmanv5.py
@@ -197,7 +197,7 @@ class PySolarmanV5:
         :param seq: V5 sequence number
         :type seq: bytes
         :return: V5 frame header
-        :rtype: bytearray     
+        :rtype: bytearray
 
         """
         return bytearray(
@@ -216,10 +216,12 @@ class PySolarmanV5:
         :param data: data for checksum calculation
         :type data: bytes
         :return: V5 frame trailer
-        :rtype: bytearray     
+        :rtype: bytearray
 
         """
-        return bytearray(struct.pack("<B", self._calculate_checksum(data[1:])) + self.v5_end)
+        return bytearray(
+            struct.pack("<B", self._calculate_checksum(data[1:])) + self.v5_end
+        )
 
     def _get_next_sequence_number(self) -> int:
         """
@@ -343,10 +345,12 @@ class PySolarmanV5:
         :rtype: bytearray
 
         """
-        response_frame = self._v5_header(10, self._get_response_code(frame[4]), frame[5:7]) + bytearray(
-            + struct.pack("<H", 0x0100) # Frame & sensor type?
+        response_frame = self._v5_header(
+            10, self._get_response_code(frame[4]), frame[5:7]
+        ) + bytearray(
+            +struct.pack("<H", 0x0100)  # Frame & sensor type?
             + struct.pack("<I", int(time.time()))
-            + struct.pack("<I", 0) # Offset?
+            + struct.pack("<I", 0)  # Offset?
         )
         response_frame[5] = (response_frame[5] + 1) & 0xFF
         return response_frame + self._v5_trailer(response_frame)
@@ -421,10 +425,17 @@ class PySolarmanV5:
         if frame[4] != CONTROL_CODE.REQUEST and frame[4] in self.v5_control_codes:
             do_continue = False
             # Maybe do_continue = True for CONTROL_CODE.DATA|INFO|REPORT and thus process packets in the future?
-            control_name = [i for i in CONTROL_CODE.__dict__ if CONTROL_CODE.__dict__[i]==frame[4]][0]
+            control_name = [
+                i for i in CONTROL_CODE.__dict__ if CONTROL_CODE.__dict__[i] == frame[4]
+            ][0]
             self.log.debug("[%s] V5_%s: %s", self.serial, control_name, frame.hex(" "))
             response_frame = self._v5_time_response_frame(frame)
-            self.log.debug("[%s] V5_%s RESP: %s", self.serial, control_name, response_frame.hex(" "))
+            self.log.debug(
+                "[%s] V5_%s RESP: %s",
+                self.serial,
+                control_name,
+                response_frame.hex(" "),
+            )
         return do_continue, response_frame
 
     def _handle_protocol_frame(self, frame: bytes) -> bool:

--- a/pysolarmanv5/pysolarmanv5_async.py
+++ b/pysolarmanv5/pysolarmanv5_async.py
@@ -245,7 +245,7 @@ class PySolarmanV5Async(PySolarmanV5):
             loop.create_task(self.reconnect())
         else:
             if self.data_wanted_ev.is_set():
-               self._send_data(data)
+                self._send_data(data)
 
     async def _send_receive_frame(self, frame: bytes) -> bytes:
         """

--- a/tests/setup_test.py
+++ b/tests/setup_test.py
@@ -83,7 +83,9 @@ class MockDatalogger(PySolarmanV5):
             "<BB", self.sequence_number, self._get_next_sequence_number()
         )
 
-        v5_header = self._v5_header(length, self._get_response_code(CONTROL_CODE.REQUEST), self.v5_seq)
+        v5_header = self._v5_header(
+            length, self._get_response_code(CONTROL_CODE.REQUEST), self.v5_seq
+        )
 
         v5_payload = bytearray(
             self.v5_frametype
@@ -208,8 +210,10 @@ async def stream_handler(reader: asyncio.StreamReader, writer: asyncio.StreamWri
                 writer.write(bytes(enc))
                 await writer.drain()
             except V5FrameError as e:
-                """ Close immediately - allows testing with wrong serial numbers, sequence numbers etc. """
-                log.debug(f"[AioHandler] V5FrameError({' '.join(e.args)}). Closing immediately... ")
+                """Close immediately - allows testing with wrong serial numbers, sequence numbers etc."""
+                log.debug(
+                    f"[AioHandler] V5FrameError({' '.join(e.args)}). Closing immediately... "
+                )
                 break
             except Exception as e:
                 log.exception(e)
@@ -238,7 +242,6 @@ async def stream_handler(reader: asyncio.StreamReader, writer: asyncio.StreamWri
 
 
 class SolarmanServer(metaclass=_Singleton):
-
     """
     Sync version of the test server
     """

--- a/tests/test_aio_solarman.py
+++ b/tests/test_aio_solarman.py
@@ -14,7 +14,11 @@ def test_async():
     async def wrapper():
         log.debug("Async starting")
         solarman = PySolarmanV5Async(
-            "127.0.0.1", 2612749371, auto_reconnect=True, verbose=True, socket_timeout=10
+            "127.0.0.1",
+            2612749371,
+            auto_reconnect=True,
+            verbose=True,
+            socket_timeout=10,
         )
         await solarman.connect()
         log.debug("Async connected!!!")
@@ -58,14 +62,17 @@ def test_async_no_socket_available():
     async def wrapper():
         log.debug("Async NoSocketAvailable Test - starting")
         solarman = PySolarmanV5Async(
-            "127.0.0.1", 2612749271, auto_reconnect=False, verbose=True, socket_timeout=5
+            "127.0.0.1",
+            2612749271,
+            auto_reconnect=False,
+            verbose=True,
+            socket_timeout=5,
         )
         await solarman.connect()
         log.debug("Async connected!!!")
         with pytest.raises(NoSocketAvailableError) as einfo:
             res = await solarman.read_holding_registers(20, 4)
         assert einfo.type is NoSocketAvailableError
-
 
     try:
         loop = asyncio.get_running_loop()
@@ -78,14 +85,17 @@ def test_async_timeout_error():
     async def wrapper():
         log.debug("Async TimeoutError Test - starting")
         solarman = PySolarmanV5Async(
-            "127.0.0.1", 2612749271, auto_reconnect=True, verbose=True, socket_timeout=1.5
+            "127.0.0.1",
+            2612749271,
+            auto_reconnect=True,
+            verbose=True,
+            socket_timeout=1.5,
         )
         await solarman.connect()
         log.debug("Async connected!!!")
         with pytest.raises(asyncio.exceptions.TimeoutError) as einfo:
             res = await solarman.read_holding_registers(20, 4)
         assert einfo.type is asyncio.exceptions.TimeoutError
-
 
     try:
         loop = asyncio.get_running_loop()

--- a/tests/test_solarman.py
+++ b/tests/test_solarman.py
@@ -52,4 +52,3 @@ def test_sync():
         solarman.disconnect()
     except:
         pass
-

--- a/utils/solarman_decoder.py
+++ b/utils/solarman_decoder.py
@@ -1,4 +1,4 @@
-""" Parse and decode V5 frames passed via argv
+"""Parse and decode V5 frames passed via argv
 
 user@host:~/src/pysolarmanv5$ ./venv/bin/python utils/solarman_decoder.py a5 17 00 10 45 bb 00 b2 6e 3c 6a 02 00 00 00 00 00 00 00 00 00 00 00 00 00 00 01 03 00 03 00 05 75 c9 39 15
 Frame start: a5 (valid: True)
@@ -16,11 +16,11 @@ Offset Time: 0
 Frame Time: 1970-01-01 00:00:00+00:00
 Checksum: 30153 hex: 75c9 - RTU start at: 0103000300
 ========== RTU Payload - [Request] ==========
-	Slave address: 1
-	Function code: 3
-	CRC: 75c9 (valid: True)
-	Request Start Addr: 3 (03)
-	Request Quantity: 5 (05)
+        Slave address: 1
+        Function code: 3
+        CRC: 75c9 (valid: True)
+        Request Start Addr: 3 (03)
+        Request Quantity: 5 (05)
 
 """
 

--- a/utils/solarman_scan.py
+++ b/utils/solarman_scan.py
@@ -1,4 +1,4 @@
-""" Scan local network for Solarman data loggers """
+"""Scan local network for Solarman data loggers"""
 
 import socket
 from argparse import ArgumentParser


### PR DESCRIPTION
This PR adds a basic CI that executes `pytest` and `black`. This also exposed some issues that I fixed.
It also builds a docker image that is pushed to the github container registry which can be used to directly execute any of the new commands from #88.
```bash
docker run --rm ghcr.io/ngehrsitz/pysolarmanv5:1340ad4d7d475d33950b502a188a750ee7617c69
Unable to find image 'ghcr.io/ngehrsitz/pysolarmanv5:1340ad4d7d475d33950b502a188a750ee7617c69' locally
1340ad4d7d475d33950b502a188a750ee7617c69: Pulling from ngehrsitz/pysolarmanv5
f18232174bc9: Already exists                                                                                                                                                                                                            
a507b793f9af: Already exists                                                                                                                                                                                                            
85be7329d6c2: Already exists                                                                                                                                                                                                            
b0d8a12effa9: Already exists                                                                                                                                                                                                            
daadb805e6d7: Pull complete
Digest: sha256:d7abb4c13aa25b4f12fbf1d4ebc79b99772d038de9d1092ca40ab2a6f31797a6
Status: Downloaded newer image for ghcr.io/ngehrsitz/pysolarmanv5:1340ad4d7d475d33950b502a188a750ee7617c69
Available commands:
solarman-scan
solarman-uni-scan
solarman-rtu-proxy
solarman-decoder
```
