### PR TITLE
solarman_rtu_proxy.py: improve runtime stability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker/dockerfile:1
-FROM python:3.13-alpine
+# alpine causes issues with solarman_rtu_proxy.py: https://stackoverflow.com/a/77780983
+FROM python:3.13-slim
 
 # mount current directory to /app
 # install with pip

--- a/utils/solarman_rtu_proxy.py
+++ b/utils/solarman_rtu_proxy.py
@@ -15,6 +15,7 @@ Can be used with Home Assistant's native Modbus integration using config below:
 
 import argparse
 import asyncio
+import sys
 from functools import partial
 
 from pysolarmanv5 import PySolarmanV5Async
@@ -93,7 +94,11 @@ def main():
     )
     args = parser.parse_args()
 
-    asyncio.run(run_proxy(args.bind, args.port, args.logger, args.serial))
+    try:
+        asyncio.run(run_proxy(args.bind, args.port, args.logger, args.serial))
+    except Exception as e:
+        print(f"Exception: {e}")
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When running `solarman_rtu_proxy.py` from the docker container contineously I encountered a crash loop:
```
OSError: [Errno 24] No file descriptors available
ERROR:asyncio:Unhandled exception in client_connected_cb
transport: <_SelectorSocketTransport fd=7 read=polling write=<idle, bufsize=0>>
Traceback (most recent call last):
  File "/usr/local/lib/python3.13/site-packages/utils/solarman_rtu_proxy.py", line 29, in handle_client
    solarmanv5 = PySolarmanV5Async(
        logger_address, logger_serial, verbose=True, auto_reconnect=True
    )
  File "/usr/local/lib/python3.13/site-packages/pysolarmanv5/pysolarmanv5_async.py", line 66, in __init__
    self.data_wanted_ev = Event()
                          ~~~~~^^
  File "/usr/local/lib/python3.13/multiprocessing/context.py", line 93, in Event
    return Event(ctx=self.get_context())
  File "/usr/local/lib/python3.13/multiprocessing/synchronize.py", line 331, in __init__
    self._cond = ctx.Condition(ctx.Lock())
                 ~~~~~~~~~~~~~^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/multiprocessing/context.py", line 78, in Condition
    return Condition(lock, ctx=self.get_context())
  File "/usr/local/lib/python3.13/multiprocessing/synchronize.py", line 221, in __init__
    self._sleeping_count = ctx.Semaphore(0)
                           ~~~~~~~~~~~~~^^^
  File "/usr/local/lib/python3.13/multiprocessing/context.py", line 83, in Semaphore
    return Semaphore(value, ctx=self.get_context())
  File "/usr/local/lib/python3.13/multiprocessing/synchronize.py", line 133, in __init__
    SemLock.__init__(self, SEMAPHORE, value, SEM_VALUE_MAX, ctx=ctx)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/multiprocessing/synchronize.py", line 57, in __init__
    sl = self._semlock = _multiprocessing.SemLock(
                         ~~~~~~~~~~~~~~~~~~~~~~~~^
        kind, value, maxvalue, self._make_name(),
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        unlink_now)
        ^^^^^^^^^^^
```
This PR:

1. Exits with a non-zero status code, thus causing the docker container to be restarted instead of contineoulsy printing the error message
2. Switching to a debian based base image since only alpine appears to be affected by this issue: https://stackoverflow.com/questions/77679957/python-multiprocessing-no-file-descriptors-available-error-inside-docker-alpine
https://gitlab.alpinelinux.org/alpine/aports/-/issues/15651